### PR TITLE
Incorporation of upstream changes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015 Johannes Köster <johannes.koester@tu-dortmund.de>
+Copyright (c) 2012-2022 Johannes Köster <johannes.koester@tu-dortmund.de>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/ftplugin/snakemake.vim
+++ b/ftplugin/snakemake.vim
@@ -1,1 +1,121 @@
-runtime! ftplugin/python.vim
+" Only do this when not done yet for this buffer
+if exists('b:did_ftplugin')
+    finish
+endif
+
+" Behaves mostly like Python
+runtime! ftplugin/python.vim ftplugin/python_*.vim ftplugin/python/*.vim
+
+
+"
+" Folding
+"
+setlocal foldmethod=expr
+setlocal foldexpr=GetSnakemakeFold(v:lnum)
+
+function! GetSnakemakeFold(lnum)
+    " fold preamble
+    if a:lnum == 1
+        return '>1'
+    endif
+
+    let thisline = getline(a:lnum)
+
+    " blank lines end folds
+    if thisline =~? '\v^\s*$'
+        return '-1'
+    " start fold on top level rules or python objects
+    elseif thisline =~? '\v^(rule|def|checkpoint|class)'
+        return '>1'
+    elseif thisline =~? '\v^\S'
+        if PreviousLineIndented(a:lnum) && NextRuleIndented(a:lnum)
+            return '>1'
+        endif
+    endif
+
+    return '='
+
+endfunction
+
+function! NextRuleIndented(lnum)
+    let numlines = line('$')
+    let current = a:lnum + 1
+
+    while current <= numlines
+        let thisline = getline(current)
+        if thisline =~? '\v^(rule|def|checkpoint|class)'
+            return 0
+        elseif thisline =~? '\v^\s+(rule|checkpoint)'
+            return 1
+        endif
+
+        let current += 1
+    endwhile
+
+    return 0
+endfunction
+
+function! PreviousLineIndented(lnum)
+    let current = a:lnum - 1
+
+    while current >= 1
+        let thisline = getline(current)
+        if thisline =~? '\v^\S'
+            return 0
+        elseif thisline =~? '\v^\s+\S'
+            return 1
+        endif
+
+        let current -= 1
+    endwhile
+
+    return 0
+endfunction
+
+
+"
+" Sections
+"
+function! s:NextSection(type, backwards, visual)
+    if a:visual
+        normal! gv
+    endif
+
+    if a:type == 1
+        let pattern = '\v(^rule|^checkpoint|^def|%^)'
+    elseif a:type == 2
+        let pattern = '\v\n\zs\n^(rule|checkpoint|def)'
+    endif
+
+    if a:backwards
+        let dir = '?'
+    else
+        let dir = '/'
+    endif
+
+    execute 'silent normal! ' . dir . pattern . dir . "\r"
+endfunction
+
+noremap <script> <buffer> <silent> ]]
+        \ :call <SID>NextSection(1, 0, 0)<cr>
+
+noremap <script> <buffer> <silent> [[
+        \ :call <SID>NextSection(1, 1, 0)<cr>
+
+noremap <script> <buffer> <silent> ][
+        \ :call <SID>NextSection(2, 0, 0)<cr>
+
+noremap <script> <buffer> <silent> []
+        \ :call <SID>NextSection(2, 1, 0)<cr>
+
+vnoremap <script> <buffer> <silent> ]]
+        \ :<c-u>call <SID>NextSection(1, 0, 1)<cr>
+
+vnoremap <script> <buffer> <silent> [[
+        \ :<c-u>call <SID>NextSection(1, 1, 1)<cr>
+
+vnoremap <script> <buffer> <silent> ][
+        \ :<c-u>call <SID>NextSection(2, 0, 1)<cr>
+
+vnoremap <script> <buffer> <silent> []
+        \ :<c-u>call <SID>NextSection(2, 1, 1)<cr>

--- a/syntax/snakemake.vim
+++ b/syntax/snakemake.vim
@@ -1,4 +1,131 @@
 " Vim syntax file
+" Language: Snakemake (extended from python.vim)
+" Author: Jay Hesselberth (jay.hesselberth@gmail.com)
+" Last Change: 2020 Oct 6
+
+
+if exists('b:current_syntax')
+    finish
+endif
+
+" load settings from parent Python syntax
+runtime! syntax/python.vim
+
+
+" Snakemake rules, as of version 7.8.2
+" see https://snakemake.readthedocs.io/en/v7.8.2/snakefiles/writing_snakefiles.html
+"
+" snakemake    = statement | rule | include | workdir | module | configfile | container
+" rule         = "rule" (identifier | "") ":" ruleparams
+" include      = "include:" stringliteral
+" workdir      = "workdir:" stringliteral
+" module       = "module" identifier ":" moduleparams
+" configfile   = "configfile" ":" stringliteral
+" userule      = "use" "rule" (identifier | "*") "from" identifier ["as" identifier] ["with" ":" norunparams]
+" ni           = NEWLINE INDENT
+" norunparams  = [ni input] [ni output] [ni params] [ni message] [ni threads] [ni resources] [ni log] [ni conda] [ni container] [ni benchmark] [ni cache]
+" ruleparams   = norunparams [ni (run | shell | script | notebook)] NEWLINE snakemake
+" input        = "input" ":" parameter_list
+" output       = "output" ":" parameter_list
+" params       = "params" ":" parameter_list
+" log          = "log" ":" parameter_list
+" benchmark    = "benchmark" ":" statement
+" cache        = "cache" ":" bool
+" message      = "message" ":" stringliteral
+" threads      = "threads" ":" integer
+" resources    = "resources" ":" parameter_list
+" version      = "version" ":" statement
+" conda        = "conda" ":" stringliteral
+" container    = "container" ":" stringliteral
+" run          = "run" ":" ni statement
+" shell        = "shell" ":" stringliteral
+" script       = "script" ":" stringliteral
+" notebook     = "notebook" ":" stringliteral
+" moduleparams = [ni snakefile] [ni metawrapper] [ni config] [ni skipval]
+" snakefile    = "snakefile" ":" stringliteral
+" metawrapper  = "meta_wrapper" ":" stringliteral
+" config       = "config" ":" stringliteral
+" skipval      = "skip_validation" ":" stringliteral
+
+" general directives (e.g. input)
+syn keyword pythonStatement
+      \ benchmark
+      \ conda
+      \ configfile
+      \ container
+      \ default_target
+      \ group
+      \ include
+      \ input
+      \ localrules
+      \ log
+      \ message
+      \ notebook
+      \ onerror
+      \ onstart
+      \ onsuccess
+      \ output
+      \ params
+      \ priority
+      \ resources
+      \ ruleorder
+      \ run
+      \ scattergather
+      \ script
+      \ shadow
+      \ shell
+      \ singularity
+      \ snakefile
+      \ template_engine
+      \ threads
+      \ version
+      \ wildcard_constraints
+      \ wildcards
+      \ workdir
+      \ wrapper
+
+" directives with a label (e.g. rule)
+syn keyword pythonStatement
+      \ checkpoint
+      \ rule
+      \ subworkflow
+      \ nextgroup=pythonFunction skipwhite
+
+" common snakemake objects
+syn keyword pythonBuiltinObj
+      \ Paramspace
+      \ checkpoints
+      \ config
+      \ gather
+      \ rules
+      \ scatter
+      \ workflow
+
+" snakemake functions
+syn keyword pythonBuiltinFunc
+      \ ancient
+      \ directory
+      \ expand
+      \ multiext
+      \ pipe
+      \ protected
+      \ read_job_properties
+      \ service
+      \ temp
+      \ touch
+      \ unpack
+
+" similar to special def and class treatment from python.vim, except
+" parenthetical part of def and class
+syn match pythonFunction
+      \ "\%(\%(rule\s\|subworkflow\s\|checkpoint\s\)\s*\)\@<=\h\w*" contained
+
+syn sync match pythonSync grouphere NONE "^\s*\%(rule\|subworkflow\|checkpoint\)\s\+\h\w*\s*"
+
+let b:current_syntax = 'snakemake'
+
+" vim:set sw=2 sts=2 ts=8 noet:
+" Vim syntax file
 " Language:	Snakemake (extended from python.vim)
 
 " load settings from system python.vim (7.4)
@@ -33,7 +160,7 @@ syn keyword pythonStatement	rule subworkflow nextgroup=pythonFunction skipwhite
 
 " similar to special def and class treatment from python.vim, except
 " parenthetical part of def and class
-syn match   pythonFunction
+syn match pythonFunction
       \ "\%(\%(rule\s\|subworkflow\s\)\s*\)\@<=\h\w*" contained
 
 syn sync match pythonSync grouphere NONE "^\s*\%(rule\|subworkflow\)\s\+\h\w*\s*"

--- a/syntax/snakemake.vim
+++ b/syntax/snakemake.vim
@@ -54,6 +54,7 @@ syn keyword pythonStatement
       \ configfile
       \ container
       \ default_target
+      \ envmodules
       \ group
       \ include
       \ input


### PR DESCRIPTION
Hi,

unfortunately, @alerque's proposal to move the vim plugin from the Snakemake repository to its own repo within the org (https://github.com/snakemake/snakemake/issues/254) has not picked up steam.

Since emergence of this fork however, further changes have been made upstream to support more of the Snakemake syntax as well as folding. On the other hand, sensible changes from this fork (such as the ability to load a parent Python syntax other than the system one), have not made it upstream.

Consequently, I have created _yet another fork_ to unite the best of both worlds. I would be more than happy to consolidate this here.